### PR TITLE
Correcting articles not displayed

### DIFF
--- a/app/src/main/java/org/mbach/lemonde/home/RssParser.java
+++ b/app/src/main/java/org/mbach/lemonde/home/RssParser.java
@@ -44,7 +44,7 @@ class RssParser {
         try {
             XmlPullParser parser = Xml.newPullParser();
             parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, false);
-            InputStream s = new ByteArrayInputStream(stream.getBytes( "ISO-8859-1"));
+            InputStream s = new ByteArrayInputStream(stream.getBytes());
             parser.setInput(s, "UTF-8");
             parser.nextTag();
             parser.require(XmlPullParser.START_TAG, null, TAG_RSS);

--- a/app/src/main/java/org/mbach/lemonde/home/RssParser.java
+++ b/app/src/main/java/org/mbach/lemonde/home/RssParser.java
@@ -44,7 +44,7 @@ class RssParser {
         try {
             XmlPullParser parser = Xml.newPullParser();
             parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, false);
-            InputStream s = new ByteArrayInputStream(stream.getBytes());
+            InputStream s = new ByteArrayInputStream(stream.getBytes( "ISO-8859-1"));
             parser.setInput(s, "UTF-8");
             parser.nextTag();
             parser.require(XmlPullParser.START_TAG, null, TAG_RSS);

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.5.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Nov 26 21:58:42 CET 2018
+#Fri Aug 30 22:11:08 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
Since a modification in LeMonde HTML page, datas are not available in HTML JSON to display an article content.
I added a new method extractDataFromHTML, which extract an article directly from the HTML DOM.

It can extract images, subtitles, paragraphs and tweets.

It closes #16.