### PR TITLE
Gradle wrapper version 5.6.2

### DIFF
--- a/app/gradle/wrapper/gradle-wrapper.properties
+++ b/app/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
According to the fdroid [build log](https://f-droid.org/wiki/page/org.mbach.lemonde/lastbuild),  the gradle-wrapper version is too low:

```
FAILURE: Build failed with an exception.

* Where:
Build file '/home/vagrant/build/org.mbach.lemonde/app/build.gradle' line: 1

* What went wrong:
A problem occurred evaluating project ':app'.
> Failed to apply plugin [id 'com.android.application']
   > Minimum supported Gradle version is 5.4.1. Current version is 4.10. If using the gradle wrapper, try editing the distributionUrl in /home/vagrant/build/org.mbach.lemonde/app/gradle/wrapper/gradle-wrapper.properties to gradle-5.4.1-all.zip
```
This PR sets the gradle-version to 5.6.2.

It should close #19. Don't forget to include the apk as an asset of the version, I think fdroid needs it. :wink: 