### PR TITLE
Article images

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,8 +17,8 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.palette:palette:1.0.0'
-    implementation 'com.google.android.material:material:1.0.0'
-    implementation 'org.jsoup:jsoup:1.10.3'
+    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'org.jsoup:jsoup:1.12.1'
     implementation 'com.squareup.picasso:picasso:2.5.2'
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'

--- a/app/src/main/java/org/mbach/lemonde/LeMondeDB.java
+++ b/app/src/main/java/org/mbach/lemonde/LeMondeDB.java
@@ -172,7 +172,7 @@ public class LeMondeDB {
         values.put(FavEntry.COL_TITLE, favorite.getTitle());
         values.put(FavEntry.COL_CATEGORY, favorite.getCategory());
         values.put(FavEntry.COL_LINK, favorite.getLink());
-        values.put(FavEntry.COL_ENCLOSURE, favorite.getEnclosure());
+        values.put(FavEntry.COL_ENCLOSURE, favorite.getMediaContent());
         values.put(FavEntry.COL_DATE, favorite.getPubDate());
         long id = sqLiteDatabase.insert(FavEntry.TABLE, null, values);
         close();

--- a/app/src/main/java/org/mbach/lemonde/article/ArticleActivity.java
+++ b/app/src/main/java/org/mbach/lemonde/article/ArticleActivity.java
@@ -570,6 +570,16 @@ public class ArticleActivity extends AppCompatActivity {
         dates.setText(doc.select(".article__header .meta__date").text());
         readTime.setText(doc.select(".article__header .meta__reading-time").text());
 
+        // Other page format...
+        if(headLine.getText().length() == 0) {
+            fromHtml(headLine, doc.select(".article__heading .article__title").html());
+            fromHtml(description, doc.select(".article__heading .article__desc").html());
+
+            authors.setText(doc.select(".article__heading .meta__authors").text());
+            dates.setText(doc.select(".article__heading .meta__publisher").text());
+            readTime.setText(doc.select(".article__heading .meta__reading-time").text());
+        }
+
         models.add(new Model(headLine));
         models.add(new Model(authors));
         models.add(new Model(dates));

--- a/app/src/main/java/org/mbach/lemonde/favorites/FavoritesActivity.java
+++ b/app/src/main/java/org/mbach/lemonde/favorites/FavoritesActivity.java
@@ -115,7 +115,7 @@ public class FavoritesActivity extends AppCompatActivity {
         Bundle extras = new Bundle();
         extras.putInt(Constants.EXTRA_RSS_ARTICLE_ID, view.getId());
         extras.putString(Constants.EXTRA_RSS_LINK, favoritesModel.getLink());
-        extras.putString(Constants.EXTRA_RSS_IMAGE, favoritesModel.getEnclosure());
+        extras.putString(Constants.EXTRA_RSS_IMAGE, favoritesModel.getMediaContent());
         extras.putString(Constants.EXTRA_RSS_TITLE, favoritesModel.getTitle());
         extras.putLong(Constants.EXTRA_RSS_DATE, favoritesModel.getPubDate());
         intent.putExtras(extras);

--- a/app/src/main/java/org/mbach/lemonde/home/MainActivity.java
+++ b/app/src/main/java/org/mbach/lemonde/home/MainActivity.java
@@ -143,7 +143,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
                     extras.putInt(Constants.EXTRA_RSS_ARTICLE_ID, rssItem.getArticleId());
                     extras.putString(Constants.EXTRA_RSS_LINK, rssItem.getLink());
-                    extras.putString(Constants.EXTRA_RSS_IMAGE, rssItem.getEnclosure());
+                    extras.putString(Constants.EXTRA_RSS_IMAGE, rssItem.getMediaContent());
                     extras.putString(Constants.EXTRA_RSS_TITLE, rssItem.getTitle());
                     extras.putLong(Constants.EXTRA_RSS_DATE, rssItem.getPubDate());
 

--- a/app/src/main/java/org/mbach/lemonde/home/RecyclerRssItemAdapter.java
+++ b/app/src/main/java/org/mbach/lemonde/home/RecyclerRssItemAdapter.java
@@ -52,7 +52,7 @@ public class RecyclerRssItemAdapter extends RecyclerView.Adapter<RecyclerRssItem
         RssItem item = items.get(position);
         holder.title.setText(item.getTitle());
         holder.image.setImageBitmap(null);
-        Picasso.with(holder.image.getContext()).load(item.getEnclosure()).into(holder.image);
+        Picasso.with(holder.image.getContext()).load(item.getMediaContent()).into(holder.image);
         holder.itemView.setTag(item);
     }
 

--- a/app/src/main/java/org/mbach/lemonde/home/RssItem.java
+++ b/app/src/main/java/org/mbach/lemonde/home/RssItem.java
@@ -25,6 +25,8 @@ public class RssItem implements Parcelable {
     @Nullable
     private String enclosure = null;
     @Nullable
+    private String mediaContent = null;
+    @Nullable
     private String category = null;
     private long pubDate;
     private final int type;
@@ -45,6 +47,7 @@ public class RssItem implements Parcelable {
         articleId = in.readInt();
         enclosure = in.readString();
         pubDate = in.readLong();
+        mediaContent = in.readString();
         type = ARTICLE_TYPE;
     }
 
@@ -77,6 +80,15 @@ public class RssItem implements Parcelable {
 
     public void setEnclosure(@Nullable String enclosure) {
         this.enclosure = enclosure;
+    }
+
+    @Nullable
+    public String getMediaContent() {
+        return mediaContent;
+    }
+
+    public void setMediaContent(@Nullable String mediaContent) {
+        this.mediaContent = mediaContent;
     }
 
     public int getArticleId() {
@@ -120,5 +132,6 @@ public class RssItem implements Parcelable {
         dest.writeInt(articleId);
         dest.writeString(enclosure);
         dest.writeLong(pubDate);
+        dest.writeString(mediaContent);
     }
 }

--- a/app/src/main/java/org/mbach/lemonde/home/RssParser.java
+++ b/app/src/main/java/org/mbach/lemonde/home/RssParser.java
@@ -32,6 +32,7 @@ class RssParser {
     private static final String TAG_TITLE = "title";
     private static final String TAG_LINK = "link";
     private static final String TAG_ENCLOSURE = "enclosure";
+    private static final String TAG_MEDIA_CONTENT = "media:content";
     private static final String TAG_RSS = "rss";
     private static final String TAG_ITEM = "item";
     private static final String TAG_GUID = "guid";
@@ -79,6 +80,9 @@ class RssParser {
                     case XmlPullParser.START_TAG:
                         if (tagName.equalsIgnoreCase(TAG_ITEM)) {
                             item = new RssItem(RssItem.ARTICLE_TYPE);
+                        } else if (tagName.equalsIgnoreCase(TAG_MEDIA_CONTENT)) {
+                            text = parser.getAttributeValue(null, "url");
+                            item.setMediaContent(text);
                         }
                         break;
                     case XmlPullParser.TEXT:

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
 
     <!-- Default theme is dark -->

--- a/app/src/main/res/values-v23/styles.xml
+++ b/app/src/main/res/values-v23/styles.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
 
     <style name="DarkTheme" parent="Theme.AppCompat.NoActionBar">

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="CustomTheme">
-        <attr name="defaultText" />
-        <attr name="authorDateText" />
-        <attr name="articleHeaderGradient" />
-        <attr name="colorBackgroundDrawer" />
-        <attr name="deleteFavoriteIcon" />
+        <attr name="defaultText" format="string" />
+        <attr name="authorDateText"  format="string" />
+        <attr name="articleHeaderGradient" format="color" />
+        <attr name="colorBackgroundDrawer" format="color" />
+        <attr name="deleteFavoriteIcon"  format="reference" />
     </declare-styleable>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name" translatable="false">LeMonde</string>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <color name="primary">#424242</color>

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.0'
     }
 }
 


### PR DESCRIPTION
Several changes in that PR:
 - With the new Android Studio 3.6, attr in attr.xml were not recognized due to format not present. I also added some <xml... /> when it was missing
 - Article images suddenly disappeared... I think lemonde changed their RSS feed and enclosure are not present now. I parsed image from media:content
 - On some articles, titles were not displayed