### PR TITLE
Remove non-FOSS deps from react-native-device-info

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -87,6 +87,12 @@ dependencies {
     implementation "com.facebook.react:react-native:+"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
 
+    implementation(project(':react-native-device-info')) {
+        exclude group: 'com.google.firebase'
+        exclude group: 'com.google.android.gms'
+        exclude group: 'com.android.installreferrer'
+    }
+
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
       exclude group:'com.facebook.fbjni'
     }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react": "17.0.1",
     "react-content-loader": "^5.1.4",
     "react-native": "^0.63.4",
-    "react-native-device-info": "^7.3.1",
+    "react-native-device-info": "^8.0.0",
     "react-native-gesture-handler": "^1.9.0",
     "react-native-localize": "^2.0.1",
     "react-native-paper": "^4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4521,10 +4521,10 @@ react-is@^16.12.0, react-is@^16.13.0, react-is@^16.7.0, react-is@^16.8.1, react-
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-native-device-info@^7.3.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-7.3.1.tgz#6c4b0120d57872a2f7534332323306b386828a3d"
-  integrity sha512-RQP3etbmXsOlcaxHeHNug68nRli02S9iGC7TbaXpkvyyevIuRogfnrI71sWtqmlT91kdpYAOYKmNfRL9LOSKVw==
+react-native-device-info@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-8.0.0.tgz"
+  integrity sha512-7/DOEhg8GtyW1hpVtWf8F6RvGLaFaOGmex+IkmiBWQC2uW4NFDcfXm+lMMZnduFavTyUTX7AF6lAM3y286cEfA==
 
 react-native-gesture-handler@^1.9.0:
   version "1.9.0"


### PR DESCRIPTION
Fix https://github.com/MBach/LeMondeRssReader/issues/35

Small issue, in `yarn.lock`, where does the hash at the end of the filename come from?

/PS: I build this and it runs ok in my testing.